### PR TITLE
Add reward component telemetry logging

### DIFF
--- a/snakepython/train_dqn.py
+++ b/snakepython/train_dqn.py
@@ -21,6 +21,7 @@ from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv
 from stable_baselines3.common.vec_env.util import make_vec_env
 
 from snake_env import SnakeEnv
+from utils.reward_telemetry import RewardTelemetryTracker, WINDOW_SIZES
 
 ANSI_GREEN = "\033[92m"
 ANSI_YELLOW = "\033[93m"
@@ -37,6 +38,8 @@ class EpisodeTracker(BaseCallback):
         self.episode_lengths: List[int] = []
         self.episode_fruits: List[int] = []
         self.last_log_step = 0
+        self.reward_tracker = RewardTelemetryTracker(SnakeEnv.REWARD_COMPONENTS)
+        self._have_reward_data = False
 
     def _on_step(self) -> bool:
         infos = self.locals.get("infos", [])
@@ -53,6 +56,9 @@ class EpisodeTracker(BaseCallback):
                     f"{coloured}Episode | Reward: {info['episode']['r']:.2f} | "
                     f"Length: {info['episode']['l']} | Fruits: {info.get('fruits', 0)}{ANSI_RESET}"
                 )
+            if "reward_breakdown" in info:
+                self.reward_tracker.update(info["reward_breakdown"])
+                self._have_reward_data = True
 
         if self.num_timesteps - self.last_log_step >= self.log_interval:
             self.last_log_step = self.num_timesteps
@@ -67,7 +73,30 @@ class EpisodeTracker(BaseCallback):
                     f"{ANSI_GREEN}Step {self.num_timesteps:,} | Avg Reward (20 ep): {mean_r:.2f} | "
                     f"Avg Len: {mean_l:.1f} | Avg Fruits: {mean_f:.2f}{ANSI_RESET}"
                 )
+            if self._have_reward_data:
+                self._log_reward_components()
         return True
+
+    def _log_reward_components(self) -> None:
+        stats = self.reward_tracker.stats()
+        print(self.reward_tracker.format_table())
+        for component, component_stats in stats.items():
+            self._record_if_finite(
+                f"snake/reward_components/{component}/last", component_stats["last"]
+            )
+            for window_size in WINDOW_SIZES:
+                key = f"avg_{window_size}"
+                self._record_if_finite(
+                    f"snake/reward_components/{component}/{key}", component_stats[key]
+                )
+            self._record_if_finite(
+                f"snake/reward_components/{component}/std", component_stats["std"]
+            )
+
+    def _record_if_finite(self, key: str, value: float) -> None:
+        if np.isnan(value):
+            return
+        self.logger.record(key, value)
 
 
 def parse_args() -> argparse.Namespace:

--- a/snakepython/utils/reward_telemetry.py
+++ b/snakepython/utils/reward_telemetry.py
@@ -1,0 +1,83 @@
+"""Utilities for aggregating and formatting reward component telemetry."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, MutableMapping, Sequence
+
+import math
+import numpy as np
+
+WINDOW_SIZES: Sequence[int] = (1, 10, 100, 1000)
+
+
+@dataclass
+class RewardTelemetryTracker:
+    """Track reward component trends across multiple rolling windows."""
+
+    components: Sequence[str]
+    window_sizes: Sequence[int] = WINDOW_SIZES
+    component_windows: MutableMapping[str, Dict[int, deque]] = field(init=False)
+    component_history: MutableMapping[str, List[float]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.component_windows = {
+            component: {size: deque(maxlen=size) for size in self.window_sizes}
+            for component in self.components
+        }
+        self.component_history = {component: [] for component in self.components}
+
+    def update(self, breakdown: Mapping[str, float]) -> None:
+        for component in self.components:
+            value = float(breakdown.get(component, 0.0))
+            for window_size in self.window_sizes:
+                self.component_windows[component][window_size].append(value)
+            self.component_history[component].append(value)
+
+    def _mean(self, values: deque) -> float:
+        if not values:
+            return math.nan
+        return float(np.mean(values))
+
+    def _std(self, values: List[float]) -> float:
+        if not values:
+            return math.nan
+        return float(np.std(values))
+
+    def stats(self) -> Dict[str, Dict[str, float]]:
+        summary: Dict[str, Dict[str, float]] = {}
+        for component in self.components:
+            comp_windows = self.component_windows[component]
+            last = comp_windows[1][-1] if comp_windows[1] else math.nan
+            summary[component] = {
+                "last": last,
+                **{f"avg_{size}": self._mean(comp_windows[size]) for size in self.window_sizes},
+                "std": self._std(self.component_history[component]),
+            }
+        return summary
+
+    def format_table(self) -> str:
+        stats = self.stats()
+        header = "Component        Last    Avg10    Avg100   Avg1000     Std"
+        lines = ["Reward component trends:", header]
+        for component in self.components:
+            comp_stats = stats[component]
+            line = (
+                f"{component:15s}"
+                f" {self._format_value(comp_stats['last']):>7}"
+                f" {self._format_value(comp_stats['avg_10']):>8}"
+                f" {self._format_value(comp_stats['avg_100']):>8}"
+                f" {self._format_value(comp_stats['avg_1000']):>9}"
+                f" {self._format_value(comp_stats['std']):>9}"
+            )
+            lines.append(line)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_value(value: float) -> str:
+        if math.isnan(value):
+            return "   -"
+        return f"{value:6.2f}"
+
+
+__all__ = ["RewardTelemetryTracker", "WINDOW_SIZES"]


### PR DESCRIPTION
## Summary
- instrument `SnakeEnv` to accumulate per-component reward information and expose it via step info
- add a reusable telemetry tracker for rolling reward component statistics
- extend PPO and DQN episode trackers to print component trend tables and push the metrics to TensorBoard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62ceab0bc8324b1ca31cba6d97f69