### PR TITLE
Launch IDLE snake game by default

### DIFF
--- a/snakepython/README.md
+++ b/snakepython/README.md
@@ -52,6 +52,13 @@ python idle_snake.py --load-model idle_dqn.npz --play --autopilot
 Terminalen skriver ut träningsstatistik var tionde episod och autopilot kan
 slås av/på i spelet genom att trycka på `A`.
 
+Vill du hellre använda det grafiska träningsgränssnittet från IDLE kan du
+starta det direkt:
+
+```bash
+python idle_snake.py --trainer-ui
+```
+
 ## Manuella installationssteg
 
 Föredrar du att göra allt manuellt kan du följa dessa steg:

--- a/snakepython/idle_snake.py
+++ b/snakepython/idle_snake.py
@@ -2105,6 +2105,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--play", action="store_true", help="Starta Tkinter-spelet")
     parser.add_argument("--autopilot", action="store_true", help="Aktivera autopilot när spelet startas")
     parser.add_argument(
+        "--trainer-ui",
+        action="store_true",
+        help="Starta träningsgränssnittet i stället för spelet vid standardkörning",
+    )
+    parser.add_argument(
         "--visualize-training",
         action="store_true",
         help="Visa träningsmiljön live i ett Tkinter-fönster",
@@ -2143,7 +2148,10 @@ def main(argv: Optional[List[str]] = None) -> None:
             f"Bäst: {best:.2f} | Sämst: {worst:.2f}"
         )
 
-    if args.play or (args.autopilot and agent is not None):
+    default_run = args.train == 0 and args.evaluate == 0 and not args.play and not args.trainer_ui
+    should_play = args.play or args.autopilot or default_run
+
+    if should_play:
         try:
             start_game(agent=agent, autopilot=args.autopilot)
         except tk.TclError as exc:  # pragma: no cover - headless safeguard
@@ -2153,8 +2161,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 file=sys.stderr,
             )
             raise SystemExit(1) from exc
-    elif args.train == 0 and args.evaluate == 0:
-        # Default behaviour when running without flaggar: visa den nya träningskontrollen.
+    elif args.trainer_ui:
+        # Starta träningskontrollen när --trainer-ui används.
         try:
             start_idle_trainer_ui(load_path=args.load_model if agent is None else None)
         except tk.TclError as exc:  # pragma: no cover - headless safeguard


### PR DESCRIPTION
## Summary
- launch the Tkinter snake game automatically when running `idle_snake.py` without flags
- add a `--trainer-ui` switch to open the training interface on demand
- document the new flag in the README so users can still access the trainer from IDLE

## Testing
- python -m compileall snakepython/idle_snake.py

------
https://chatgpt.com/codex/tasks/task_e_68e63aa555a4832486cf49a906ad0a26